### PR TITLE
Replaced mongodb helm repo to older

### DIFF
--- a/deploy/Chart.yaml
+++ b/deploy/Chart.yaml
@@ -3,8 +3,8 @@ name: stakater-nordmart-review
 description: A Helm chart for Kubernetes
 dependencies:
 - name: mongodb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.15.4
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami
+  version: 12.1.15
 - name: application
   repository: https://stakater.github.io/stakater-charts
   version: 2.1.18


### PR DESCRIPTION
We are facing errors while using OCI repo, so replacing the older repo for MongoDB.